### PR TITLE
feat: support Laravel 13

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3, 8.4, 8.5]
+        php: [8.3, 8.4, 8.5]
         stability: [prefer-stable]
 
     name: PHP ${{ matrix.php }} - STABILITY ${{ matrix.stability }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.3
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, gd, memcached, oci8
           tools: composer:v2
           coverage: none

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,3 @@
-# Changelog
+## v13.0.0 - 2026-03-18
 
-All Notable changes to `laravel-auditable` will be documented in this file.
-
-## [Unreleased]
-
-## v12.0.2 - 2025-03-22
-
-- fix: prevent touch model #30
-
-## v12.0.1 - 2025-03-04
-
-- fix: Prevent not dirty model to get dirtied #34
-- fix: #33
-
-## v12.0.0 - 2025-02-28
-
-- Laravel 12 Support #32
+- Laravel 13 support

--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ This package automatically inserts/updates an audit log on your table on who cre
 | 5.x-10.x | 4.x     |
 | 11.x     | 11.x    |
 | 12.x     | 12.x    |
+| 13.x     | 13.x    |
 
 ## Install via Composer
 
 ```bash
-composer require yajra/laravel-auditable:^12
+composer require yajra/laravel-auditable:^13
 ```
 
 ## Publish config file

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
         "illuminate/database": "^13.0"
     },
     "require-dev": {
-        "larastan/larastan": "^3.1",
-        "laravel/pint": "^1.21",
-        "rector/rector": "^2.0.9",
+        "larastan/larastan": "^3.9.3",
+        "laravel/pint": "^1.29",
+        "rector/rector": "^2.3.9",
         "orchestra/testbench": "^11.0",
-        "pestphp/pest": "^3.7.4",
-        "pestphp/pest-plugin-laravel": "^3.1"
+        "pestphp/pest": "^4.4.2",
+        "pestphp/pest-plugin-laravel": "^4.1"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,15 @@
         }
     ],
     "require": {
-        "php": "^8.2",
-        "illuminate/support": "^12.0",
-        "illuminate/database": "^12.0"
+        "php": "^8.3",
+        "illuminate/support": "^13.0",
+        "illuminate/database": "^13.0"
     },
     "require-dev": {
         "larastan/larastan": "^3.1",
         "laravel/pint": "^1.21",
         "rector/rector": "^2.0.9",
-        "orchestra/testbench": "^10.0",
+        "orchestra/testbench": "^11.0",
         "pestphp/pest": "^3.7.4",
         "pestphp/pest-plugin-laravel": "^3.1"
     },
@@ -46,7 +46,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "12.x-dev"
+            "dev-master": "13.x-dev"
         },
         "laravel": {
             "providers": [

--- a/src/AuditableTrait.php
+++ b/src/AuditableTrait.php
@@ -17,7 +17,9 @@ trait AuditableTrait
      */
     public static function bootAuditableTrait(): void
     {
-        static::observe(new AuditableTraitObserver);
+        static::whenBooted(function () {
+            static::observe(new AuditableTraitObserver);
+        });
     }
 
     /**

--- a/src/AuditableWithDeletesTrait.php
+++ b/src/AuditableWithDeletesTrait.php
@@ -2,10 +2,11 @@
 
 namespace Yajra\Auditable;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
- * @property \Illuminate\Database\Eloquent\Model $deleter
+ * @property Model $deleter
  */
 trait AuditableWithDeletesTrait
 {

--- a/src/AuditableWithDeletesTrait.php
+++ b/src/AuditableWithDeletesTrait.php
@@ -17,7 +17,9 @@ trait AuditableWithDeletesTrait
      */
     public static function bootAuditableWithDeletesTrait(): void
     {
-        static::observe(new AuditableWithDeletesTraitObserver);
+        static::whenBooted(function () {
+            static::observe(new AuditableWithDeletesTraitObserver);
+        });
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Yajra\Auditable\Tests;
 
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Orchestra\Testbench\TestCase as BaseTestCase;
+use Yajra\Auditable\AuditableServiceProvider;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -17,7 +18,7 @@ abstract class TestCase extends BaseTestCase
     protected function getPackageProviders($app): array
     {
         return [
-            \Yajra\Auditable\AuditableServiceProvider::class,
+            AuditableServiceProvider::class,
         ];
     }
 }


### PR DESCRIPTION
This pull request upgrades the package to support Laravel 13 and PHP 8.3, dropping support for older versions. It updates dependencies, documentation, and CI workflows to reflect these changes.

**Laravel and PHP version support:**

* Updated `composer.json` to require Laravel 13 (`illuminate/support`, `illuminate/database` ^13.0) and PHP ^8.3; also updated dev dependencies for compatibility (`orchestra/testbench` ^11.0).
* Changed branch alias in `composer.json` to `13.x-dev`.

**Continuous Integration and Static Analysis:**

* Updated CI workflow (`continuous-integration.yml`) to test only on PHP 8.3, 8.4, and 8.5, removing PHP 8.2.
* Updated static analysis workflow to use PHP 8.3 instead of 8.2.

**Documentation:**

* Updated `CHANGELOG.md` to announce Laravel 13 support as of v13.0.0.
* Updated `README.md` to add Laravel 13 to the compatibility table and instruct users to require version ^13.